### PR TITLE
Fix datatype cleanup

### DIFF
--- a/tst_types.c
+++ b/tst_types.c
@@ -500,7 +500,7 @@ int tst_type_cleanup (void)
   int i;
   for (i=PREDEFINED_DATATYPES; i < TST_TYPES_NUM; i++)
     {
-      if (NULL == ((void*)types[i].mpi_datatype) || MPI_DATATYPE_NULL == types[i].mpi_datatype)
+      if (MPI_DATATYPE_NULL == types[i].mpi_datatype)
         continue;
 
       MPI_Type_free (&types[i].mpi_datatype);


### PR DESCRIPTION
The type of MPI_Datatype is not specified in the standard. They must not
be implemented as objects and can, e.g., also be implemented via integers.
Therefore, removing the incorrect comparison against NULL here.

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>