### PR TITLE
Fix array out-of-bounds access in tst_env_get_version

### DIFF
--- a/env/tst_env_get_version.c
+++ b/env/tst_env_get_version.c
@@ -32,7 +32,7 @@ int tst_env_get_version_run (struct tst_env * env)
 
   int valid_mpi_versions[][2] = { {3,1}, {3,0}, {2,2}, {2,1}, {2,0}, {1,2} };
   int i;
-  for( i = 0; i < sizeof(valid_mpi_versions); i++) {
+  for( i = 0; i < (sizeof(valid_mpi_versions)/sizeof(valid_mpi_versions[0])); i++) {
     if( valid_mpi_versions[i][0] == version && valid_mpi_versions[i][1] == subversion) {
       return 0;
     }


### PR DESCRIPTION
Fix array out-of-bounds access in tst_env_get_version that was caused by an  incorrect computation of the size of the multi dimensional array `valid_mpi_versions`.

Thanks to BenWibking for reporting the issue in https://github.com/open-mpi/mpi-test-suite/issues/9.

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>