### PR TITLE
remove broken MPI_TYPE_MIX_LB_UB

### DIFF
--- a/compile_info.h
+++ b/compile_info.h
@@ -1,4 +1,4 @@
-#ifndef BINRAY_INFO_H
+#ifndef BINARY_INFO_H
 #define BINARY_INFO_H
 
 #include <stdio.h>

--- a/env/tst_env_get_version.c
+++ b/env/tst_env_get_version.c
@@ -32,7 +32,7 @@ int tst_env_get_version_run (struct tst_env * env)
 
   int valid_mpi_versions[][2] = { {3,1}, {3,0}, {2,2}, {2,1}, {2,0}, {1,2} };
   int i;
-  for( i = 0; i < sizeof(valid_mpi_versions); i++) {
+  for( i = 0; i < (sizeof(valid_mpi_versions)/sizeof(valid_mpi_versions[0])); i++) {
     if( valid_mpi_versions[i][0] == version && valid_mpi_versions[i][1] == subversion) {
       return 0;
     }


### PR DESCRIPTION
The code for setting the values of this datatype makes out of bounds writes using nonsensical array offsets, causing heap corruption and an immediate crash of the test suite process. This change removes all of the broken code associated with this datatype.

Fixes https://github.com/open-mpi/mpi-test-suite/issues/8.