### PR TITLE
Log output updates

### DIFF
--- a/cmdline.ggo
+++ b/cmdline.ggo
@@ -13,7 +13,7 @@ in order, so use 'all,^exclude'."
 text "\n"
 option "atomic-io" a "enable atomicity for files in I/O for all tests that support it"
 option "num-threads" j "number of additional threads to execute the tests" int default="0"
-option "report" r "level of detail for test report" values="summary","run","full" default="summary"
+option "report" r "level of detail for test report" values="none","summary","run","full" default="summary"
 option "execution-mode" x "level of correctness testing" values="disabled","strict","relaxed" default="relaxed"
 
 option "list" l "list all available tests, communicators, datatypes and corresponding classes"

--- a/mpi_test_suite.c
+++ b/mpi_test_suite.c
@@ -435,7 +435,7 @@ int main (int argc, char * argv[])
             if (tst_test_check_sync (&tst_env))
               MPI_Barrier (MPI_COMM_WORLD);
 
-            if (tst_global_rank == 0 && tst_report > TST_REPORT_SUMMARY)
+            if (tst_global_rank == 0 && tst_report >= TST_REPORT_RUN)
               printf ("%s tests %s (%d/%d), comm %s (%d/%d), type %s (%d/%d)\n",
                       tst_test_getclass_string (tst_env.test),
                       tst_test_getdescription (tst_env.test), tst_env.test+1, num_tests,

--- a/mpi_test_suite.c
+++ b/mpi_test_suite.c
@@ -359,7 +359,7 @@ int main (int argc, char * argv[])
     str = strtok (NULL, ",");
   }
 
-  for (tst_report = TST_REPORT_SUMMARY; tst_report < TST_REPORT_MAX; tst_report++) {
+  for (tst_report = TST_REPORT_NONE; tst_report < TST_REPORT_MAX; tst_report++) {
     if (0 == strcasecmp (args_info.report_arg, tst_reports[tst_report])) {
       break;
     }
@@ -461,7 +461,7 @@ int main (int argc, char * argv[])
               MPI_Barrier (MPI_COMM_WORLD);
           }
 
-  if (tst_global_rank == 0) {
+  if (tst_global_rank == 0 && tst_report >= TST_REPORT_SUMMARY) {
     tst_test_print_failed ();
   }
 

--- a/mpi_test_suite.c
+++ b/mpi_test_suite.c
@@ -142,7 +142,7 @@ int main (int argc, char * argv[])
   MPI_Comm_rank (MPI_COMM_WORLD, &tst_global_rank);
   MPI_Comm_size (MPI_COMM_WORLD, &tst_global_size);
 
-  tst_output_init (DEBUG_LOG, TST_OUTPUT_RANK_SELF, TST_REPORT_MAX, TST_OUTPUT_TYPE_LOGFILE, "tst.log");
+  tst_output_init (DEBUG_LOG, TST_OUTPUT_RANK_SELF, TST_REPORT_NONE, TST_OUTPUT_TYPE_STDERR);
 
   char info_str[MAX_INFO_STRING_LENGTH];
   get_compiler_info(info_str);

--- a/tst_output.c
+++ b/tst_output.c
@@ -144,6 +144,10 @@ int tst_output_printf(tst_output_stream * output,
   int count;
   va_list arglist;
 
+  if (output->isopen == 0) {
+    return 0;
+  }
+
 #ifdef HAVE_MPI2_THREADS
   {
     if (tst_thread_running()) {
@@ -154,7 +158,7 @@ int tst_output_printf(tst_output_stream * output,
   }
 #endif
 
-  if ((output->isopen == 1) && (output->rank == tst_output_global_rank) && (error_level <= output->level)) {
+  if ((output->rank == tst_output_global_rank) && (error_level <= output->level)) {
     va_start(arglist, format);
     count = vfprintf (output->streamptr, format, arglist);
     fflush (output->streamptr);

--- a/tst_output.c
+++ b/tst_output.c
@@ -26,6 +26,7 @@ static int tst_output_global_rank;
 
 /* Corresponding strings to values in enum tst_report_types. */
 const char * tst_reports[] = {
+  "None",
   "Summary",
   "Run",
   "Full",

--- a/tst_output.h
+++ b/tst_output.h
@@ -26,7 +26,8 @@ typedef enum {
 
 
 typedef enum {
-  TST_REPORT_SUMMARY = 0, /**< No output, except for final summary */
+  TST_REPORT_NONE = 0,    /**< No output */
+  TST_REPORT_SUMMARY,     /**< No output, except for final summary */
   TST_REPORT_RUN,         /**< Output every test that runs, plus the previous */
   TST_REPORT_FULL,        /**< Full output, including hexdump of wrong memory */
   TST_REPORT_MAX          /**< Output everything */


### PR DESCRIPTION
Some changes related to the log output
* Add new report type 'none'
* Disable the default per MPI process log output to files for scalability (used only for debugging normally)
* Minor code improvements