### PR TITLE
Fix file simple test for non threaded tests

### DIFF
--- a/io/tst_file_simple.c
+++ b/io/tst_file_simple.c
@@ -38,8 +38,13 @@ int tst_file_simple_init (struct tst_env * env)
       memset (file_name, 0, sizeof (char)*100);
       sprintf(file_name, "%s%ld", TST_FILE_NAME, (long)getpid());
     }
-  if (0 == tst_thread_get_num())
+#ifdef HAVE_MPI2_THREADS
+  if (tst_thread_get_num() == TST_THREAD_MASTER) {
+#endif
     MPI_CHECK (MPI_Bcast(file_name, 100, MPI_CHAR, ROOT, comm));
+#ifdef HAVE_MPI2_THREADS
+  }
+#endif
   env->read_buffer = tst_type_allocvalues (env->type, env->values_num);
   tst_file_alloc(env->type, env->values_num, comm_size, file_name, comm);
 


### PR DESCRIPTION
The simple file test deadlocked when run without mpi2-threads being enabled. This was caused by calling and checking for a thread with number 0. Instead one should check for TST_THREAD_MASTER - and do not use thread related code in non-threaded runs, i.e., put ifdefs around.