### PR TITLE
Add possibility to disable MPI4 partitioned P2P tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2020-2022 High-Performance Computing Center Stuttgart,
+dnl Copyright (c) 2020-2025 High-Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart. All rights reserved.
 
 dnl Process this file with autoconf to produce a configure script.
@@ -50,6 +50,13 @@ AC_ARG_ENABLE([mpi2-dynamic],
     [enable_mpi2_dynamic=no])
 AS_IF([test "$enable_mpi2_dynamic" = "yes"],[
     AC_DEFINE([HAVE_MPI2_DYNAMIC], [1], [Define to enable MPI2 dynamic process management tests])
+])
+
+AC_ARG_ENABLE([mpi4-partitioned-p2p],
+    AS_HELP_STRING([--enable-mpi4-partitioned-p2p], [Build tests for MPI4 partitioned P2P [[default=yes]]]),,
+    [enable_mpi4_partitioned_p2p=yes])
+AS_IF([test "$enable_mpi4_partitioned_p2p" = "yes"],[
+    AC_DEFINE([HAVE_MPI4_PARTITIONED_P2P], [1], [Define to enable MPI4 partitioned P2P tests])
 ])
 
 

--- a/threaded/tst_threaded_ring_partitioned.c
+++ b/threaded/tst_threaded_ring_partitioned.c
@@ -9,6 +9,7 @@
  *
  * Date: July 19th 2023
  */
+
 #include <mpi.h>
 #include "mpi_test_suite.h"
 #include "tst_threads.h"
@@ -16,6 +17,8 @@
 #include "tst_comm.h"
 
 #include <pthread.h>
+
+#ifdef HAVE_MPI4_PARTITIONED_P2P
 
 #define TST_RANK_MASTER 0
 
@@ -236,3 +239,5 @@ int tst_threaded_ring_partitioned_cleanup(struct tst_env *env)
 
   return 0;
 }
+
+#endif /* HAVE_MPI4_PARTITIONED_P2P */

--- a/threaded/tst_threaded_ring_partitioned_many_to_one.c
+++ b/threaded/tst_threaded_ring_partitioned_many_to_one.c
@@ -10,6 +10,7 @@
  *
  * Date: July 19th 2023
  */
+
 #include <mpi.h>
 #include "mpi_test_suite.h"
 #include "tst_threads.h"
@@ -19,6 +20,8 @@
 #include <pthread.h>
 
 #define TST_RANK_MASTER 0
+
+#ifdef HAVE_MPI4_PARTITIONED_P2P
 
 static pthread_barrier_t thread_barrier;
 
@@ -246,3 +249,5 @@ int tst_threaded_ring_partitioned_many_to_one_cleanup(struct tst_env *env)
 
   return 0;
 }
+
+#endif /* HAVE_MPI4_PARTITIONED_P2P */

--- a/tst_tests.c
+++ b/tst_tests.c
@@ -1377,6 +1377,7 @@ static struct tst_test tst_tests[] = {
    &tst_threaded_comm_dup_init, &tst_threaded_comm_dup_run, &tst_threaded_comm_dup_cleanup},
 
 
+#ifdef HAVE_MPI4_PARTITIONED_P2P
   {TST_CLASS_THREADED, "Threaded ring partitioned",
    TST_MPI_COMM_SELF | TST_MPI_INTRA_COMM,
    1,
@@ -1392,6 +1393,8 @@ static struct tst_test tst_tests[] = {
    TST_MODE_RELAXED,
    TST_NONE,
    &tst_threaded_ring_partitioned_many_to_one_init, &tst_threaded_ring_partitioned_many_to_one_run, &tst_threaded_ring_partitioned_many_to_one_cleanup},
+#endif /* HAVE_MPI4_PARTITIONED_P2P */
+
 #endif
 
   {TST_CLASS_UNSPEC, "None",


### PR DESCRIPTION
Added new configure option --enable-mpi4-partitioned-p2p to enable/disable the MPI4 partitioned tests.