### PR TITLE
fix missing function declaration

### DIFF
--- a/tst_output.c
+++ b/tst_output.c
@@ -35,6 +35,7 @@ const char * tst_reports[] = {
 
 #ifdef HAVE_MPI2_THREADS
 extern int tst_thread_running (void);
+extern int tst_thread_get_num (void);
 #endif
 
 /****************************************************************************/


### PR DESCRIPTION
In tst_output.c, `tst_thread_get_num` is not declared, leading to an error when compiling with `--enable-mpi2-threads`. 
To fix this, `tst_thread_get_num` is declared as external.