### PR TITLE
assign no partition to master thread

### DIFF
--- a/threaded/tst_threaded_ring_partitioned.c
+++ b/threaded/tst_threaded_ring_partitioned.c
@@ -144,6 +144,13 @@ int tst_threaded_ring_partitioned_run(struct tst_env *env)
   int send_partition_num = thread_num;
   int recv_partition_num = (thread_num % ratio_send_to_receive == 0) ? thread_num / ratio_send_to_receive : -1;
 
+  // master thread does not work on any partitions
+  if (thread_num == TST_THREAD_MASTER)
+  {
+    send_partition_num = -1;
+    recv_partition_num = -1;
+  }
+
   // init send and recv and start both
   if (thread_num == TST_THREAD_MASTER)
   {

--- a/threaded/tst_threaded_ring_partitioned_many_to_one.c
+++ b/threaded/tst_threaded_ring_partitioned_many_to_one.c
@@ -148,6 +148,13 @@ int tst_threaded_ring_partitioned_many_to_one_run(struct tst_env *env)
   int send_partition_num = thread_num;
   int recv_partition_num = (thread_num % ratio_send_to_receive == 0) ? thread_num / ratio_send_to_receive : -1;
 
+  // master thread does not work on any partitions
+  if (thread_num == TST_THREAD_MASTER)
+  {
+    send_partition_num = -1;
+    recv_partition_num = -1;
+  }
+
   // init send and recv and start both
   if (thread_num == TST_THREAD_MASTER)
   {


### PR DESCRIPTION
Previously, the partitions were simply assigned to the threads by their respective `thread_num`, assuming numbers between 0 and the thread count. However, as the master thread has `thread_num` of -1, this could result in erroneous assignments, leading to deadlocks in the case of multiple send partitions per receive partition.
More precisely, if two threads waited for the same partition it was possible that one thread continued to wait while the other had already caused the request to be finalized.

For this reason, this PR introduces a check that assigns no partitions to the master thread.